### PR TITLE
Turn off caching for the runner container

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -138,7 +138,7 @@ case $cmd in
         ;;
     runner)
         getml  || usage "Cannot find a MarkLogic RPM"
-        $debug docker build -t "$tag" --build-arg marklogic="$marklogic" $image
+        $debug docker build --no-cache -t "$tag" --build-arg marklogic="$marklogic" $image
         ;;
     *)
         usage "Unknown command $cmd" ;;

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -6,7 +6,7 @@
 #
 #######################################################################
 
-FROM ml-docker-centos-coreos
+FROM ml-docker-coreos
 MAINTAINER Norman Walsh <norman.walsh@marklogic.com>
 
 RUN yum groupinstall -y 'Development tools' ; \

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -8,7 +8,7 @@
 #
 #######################################################################
 
-FROM ml-docker-centos-coreos
+FROM ml-docker-coreos
 MAINTAINER Norman Walsh <norman.walsh@marklogic.com>
 WORKDIR /tmp
 


### PR DESCRIPTION
With caching turned on, the build script can never update MarkLogic in the runner container.

There's nothing that needs caching in the runner Dockerfile, so I just turned off caching.

For the coreos file, the same problem exists for Java, but I don't think we want to turn off caching there. We should probably split off Java into its own uncached build but I haven't bothered to do that yet.
